### PR TITLE
Update 2012-01-29-how-artsy-uses-github-to-build-artsy.markdown to correct linked url

### DIFF
--- a/_posts/2012/2012-01-29-how-artsy-uses-github-to-build-artsy.markdown
+++ b/_posts/2012/2012-01-29-how-artsy-uses-github-to-build-artsy.markdown
@@ -7,6 +7,6 @@ tags: [github, artsy]
 comments: true
 dblog_post_id: 310
 ---
-I _heart_ Github and its magical green merge button. The entire fork/pull/merge workflow has been singlehandedly responsible for a massive amount of open-source contributions by making it so easy! I wrote a quick post on how Art.sy uses Github to build Art.sy on the new Art.sy Engineering Blog, [here](http://artsy.github.com/blog/2012/01/29/how-art-dot-sy-uses-github-to-build-art-dot-sy/).
+I _heart_ Github and its magical green merge button. The entire fork/pull/merge workflow has been singlehandedly responsible for a massive amount of open-source contributions by making it so easy! I wrote a quick post on how Art.sy uses Github to build Art.sy on the new Art.sy Engineering Blog, [here](http://artsy.github.io/blog/2012/01/29/how-art-dot-sy-uses-github-to-build-art-dot-sy/).
 
 ![]({{ site.url }}/images/posts/2012/2012-01-29-how-artsy-uses-github-to-build-artsy/image_7.jpg)


### PR DESCRIPTION
Fix typo in url, github.com became github.io