### PR TITLE
Update 2022-07-11-making-sigv4-authenticated-requests-to-managed-open…

### DIFF
--- a/_posts/2022/2022-07-11-making-sigv4-authenticated-requests-to-managed-opensearch.markdown
+++ b/_posts/2022/2022-07-11-making-sigv4-authenticated-requests-to-managed-opensearch.markdown
@@ -35,6 +35,14 @@ awscurl \
   --service es
 {% endhighlight %}
 
+### [aws-es-curl](https://github.com/joona/aws-es-curl)
+
+{% highlight bash %}
+aws-es-curl \
+  "https://search...us-west-2.es.amazonaws.com" \
+  --region us-west-2
+{% endhighlight %}
+
 ### Java
 
 #### [aws-request-signing-apache-interceptor](https://github.com/acm19/aws-request-signing-apache-interceptor)


### PR DESCRIPTION
Added an entry for `aws-es-curl` as an alternative to `curl` and `awscurl`