### PR TITLE
Fix typo: `martix` -> `matrix`

### DIFF
--- a/_posts/2021/2021-09-03-generating-task-matrix-by-looping-over-repo-files-with-github-actions.markdown
+++ b/_posts/2021/2021-09-03-generating-task-matrix-by-looping-over-repo-files-with-github-actions.markdown
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2   
       - run: |
-        ./check-manifest ${{ martix.manifest }}
+        ./check-manifest ${{ matrix.manifest }}
 {% endhighlight %}
 
 We'll definitely forget to update the matrix when a new file is created, so let's just list those files dynamically, and generate a matrix from the list.
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2   
       - run: |
-        ./check-manifest ${{ martix.manifest }}
+        ./check-manifest ${{ matrix.manifest }}
 {% endraw %}
 {% endhighlight %}
 


### PR DESCRIPTION
Fixes typo in the article _[Generating a Task Matrix by Looping over Repo Files with GitHub Actions](https://code.dblock.org/2021/09/03/generating-task-matrix-by-looping-over-repo-files-with-github-actions.html)_